### PR TITLE
添加 dtime 定时发布参数

### DIFF
--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -899,6 +899,11 @@ export default class Platform extends BaseRequest {
       if (options.source.length > 200)
         throw new Error("source can not be longer than 200 characters");
     }
+    if (!this.verifyScheduledPublishTime(options.dtime)) {
+      throw new Error(
+        `scheduledPublishTime ${options.dtime} is not valid. See method 'verifyScheduledPublishTime' for details.`
+      );
+    }
     return true;
   }
   /**
@@ -1212,6 +1217,17 @@ export default class Platform extends BaseRequest {
     this.auth.authLogin();
     return this.request.get(
       "https://member.bilibili.com/x/vupre/web/archive/human/type2/list"
+    );
+  }
+
+  /**
+   * 校验定时发布时间，返回 true 则为合法。
+   */
+  verifyScheduledPublishTime(scheduledPublishTime: number): boolean {
+    return (
+      scheduledPublishTime === undefined ||
+      (scheduledPublishTime >= Math.floor(Date.now() / 1000) + 2 * 60 * 60 &&
+        scheduledPublishTime <= Math.floor(Date.now() / 1000) + 15 * 24 * 60 * 60)
     );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,8 @@ export interface MediaOptions {
   neutral_mark?: string;
   /** 新分区 */
   human_type2?: number;
+  /** 定时发布：10位秒级时间戳。必须距离提交时间>7200秒 */
+  dtime?: number;
 }
 
 export interface MediaPartOptions {


### PR DESCRIPTION
本次 PR 新增了投稿时的**定时发布**参数选项。

**主要变更：**

- 在 `src/types/index.ts` 的 `MediaOptions` 接口里新增了 `dtime` 字段，用于支持定时发布功能，该字段为 10 位长度的秒级时间戳。
- 在 `Platform` 类（`src/platform/index.ts`）的媒体创建与更新方法中，增加了对 `dtime` 参数的校验逻辑，调用新增的 `verifyScheduledPublishTime` 方法进行验证。若时间不符合要求，则抛出相应错误。

**新增工具方法：**

- 新增 `verifyScheduledPublishTime` 方法，用于校验定时发布时间是否有效：发布时间必须至少在当前时间 2 小时之后，且不得超过 15 天。